### PR TITLE
Fix: Internal error with minimum values

### DIFF
--- a/src/main/java/de/redstoneworld/redplayerutils/AbstractValueCommand.java
+++ b/src/main/java/de/redstoneworld/redplayerutils/AbstractValueCommand.java
@@ -71,7 +71,7 @@ public abstract class AbstractValueCommand implements CommandExecutor {
                         "value", args[0]
                 ));
             } else {
-                sender.sendMessage(plugin.getLang("error." + name + "-above-max", "input", args[0]));
+                sender.sendMessage(plugin.getLang("error." + name + "-range", "input", args[0]));
             }
         } catch (NumberFormatException e) {
             sender.sendMessage(plugin.getLang("error.wrong-" + name + "", "input", args[0]));

--- a/src/main/java/de/redstoneworld/redplayerutils/commands/RedHealthCommand.java
+++ b/src/main/java/de/redstoneworld/redplayerutils/commands/RedHealthCommand.java
@@ -18,7 +18,7 @@ public class RedHealthCommand extends AbstractValueCommand {
     @Override
     protected boolean applyValue(Player target, String input) {
         double healthLevel = Double.parseDouble(input);
-        if (healthLevel > 20 || healthLevel < 0) {
+        if (healthLevel < 0 || healthLevel > 20) {
             return false;
         }
 

--- a/src/main/java/de/redstoneworld/redplayerutils/commands/RedHealthCommand.java
+++ b/src/main/java/de/redstoneworld/redplayerutils/commands/RedHealthCommand.java
@@ -18,7 +18,7 @@ public class RedHealthCommand extends AbstractValueCommand {
     @Override
     protected boolean applyValue(Player target, String input) {
         double healthLevel = Double.parseDouble(input);
-        if (healthLevel > 20) {
+        if (healthLevel > 20 || healthLevel < 0) {
             return false;
         }
 

--- a/src/main/java/de/redstoneworld/redplayerutils/commands/RedHungerCommand.java
+++ b/src/main/java/de/redstoneworld/redplayerutils/commands/RedHungerCommand.java
@@ -21,7 +21,7 @@ public class RedHungerCommand extends AbstractValueCommand {
     protected boolean applyValue(Player target, String input) {
         int foodLevel = Integer.parseInt(input);
 
-        if (foodLevel > MAX_LEVEL) {
+        if (foodLevel > MAX_LEVEL || foodLevel < 0) {
             return false;
         }
 

--- a/src/main/java/de/redstoneworld/redplayerutils/commands/RedHungerCommand.java
+++ b/src/main/java/de/redstoneworld/redplayerutils/commands/RedHungerCommand.java
@@ -21,7 +21,7 @@ public class RedHungerCommand extends AbstractValueCommand {
     protected boolean applyValue(Player target, String input) {
         int foodLevel = Integer.parseInt(input);
 
-        if (foodLevel > MAX_LEVEL || foodLevel < 0) {
+        if (foodLevel < 0 || foodLevel > MAX_LEVEL) {
             return false;
         }
 

--- a/src/main/java/de/redstoneworld/redplayerutils/commands/RedLevelCommand.java
+++ b/src/main/java/de/redstoneworld/redplayerutils/commands/RedLevelCommand.java
@@ -21,7 +21,7 @@ public class RedLevelCommand extends AbstractValueCommand {
             return false;
         }
         long level = Long.parseLong(input);
-        if (level > Integer.MAX_VALUE || level < 0) {
+        if (level < 0 || level > Integer.MAX_VALUE) {
             return false;
         }
 

--- a/src/main/java/de/redstoneworld/redplayerutils/commands/RedLevelCommand.java
+++ b/src/main/java/de/redstoneworld/redplayerutils/commands/RedLevelCommand.java
@@ -21,7 +21,7 @@ public class RedLevelCommand extends AbstractValueCommand {
             return false;
         }
         long level = Long.parseLong(input);
-        if (level > Integer.MAX_VALUE) {
+        if (level > Integer.MAX_VALUE || level < 0) {
             return false;
         }
 

--- a/src/main/java/de/redstoneworld/redplayerutils/commands/RedSaturationCommand.java
+++ b/src/main/java/de/redstoneworld/redplayerutils/commands/RedSaturationCommand.java
@@ -20,7 +20,7 @@ public class RedSaturationCommand extends AbstractValueCommand {
     protected boolean applyValue(Player target, String input) {
         float saturationLevel = Float.parseFloat(input);
 
-        if (saturationLevel > MAX_LEVEL) {
+        if (saturationLevel > MAX_LEVEL || saturationLevel < 0) {
             return false;
         }
 

--- a/src/main/java/de/redstoneworld/redplayerutils/commands/RedSaturationCommand.java
+++ b/src/main/java/de/redstoneworld/redplayerutils/commands/RedSaturationCommand.java
@@ -20,7 +20,7 @@ public class RedSaturationCommand extends AbstractValueCommand {
     protected boolean applyValue(Player target, String input) {
         float saturationLevel = Float.parseFloat(input);
 
-        if (saturationLevel > MAX_LEVEL || saturationLevel < 0) {
+        if (saturationLevel < 0 || saturationLevel > MAX_LEVEL) {
             return false;
         }
 

--- a/src/main/java/de/redstoneworld/redplayerutils/commands/RedXpCommand.java
+++ b/src/main/java/de/redstoneworld/redplayerutils/commands/RedXpCommand.java
@@ -23,7 +23,7 @@ public class RedXpCommand extends AbstractValueCommand {
             return false;
         }
         long xp = Long.parseLong(input);
-        if (xp > Integer.MAX_VALUE) {
+        if (xp > Integer.MAX_VALUE || xp < 0) {
             return false;
         }
         // Apply xp level

--- a/src/main/java/de/redstoneworld/redplayerutils/commands/RedXpCommand.java
+++ b/src/main/java/de/redstoneworld/redplayerutils/commands/RedXpCommand.java
@@ -23,7 +23,7 @@ public class RedXpCommand extends AbstractValueCommand {
             return false;
         }
         long xp = Long.parseLong(input);
-        if (xp > Integer.MAX_VALUE || xp < 0) {
+        if (xp < 0 || xp > Integer.MAX_VALUE) {
             return false;
         }
         // Apply xp level

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,21 +1,23 @@
 lang:
   error:
-    usage-foodlevel: "&4Usage: &f/hunger [<foodlevel> [<player>]]"
+    usage-hunger: "&4Usage: &f/hunger [<foodlevel> [<player>]]"
     usage-saturation: "&4Usage: &f/saturation [<saturationlevel> [<player>]]"
     usage-health: "&4Usage: &f/health [<healthlevel> [<player>]]"
     usage-xp: "&4Usage: &f/xp [<xp> [<player>]]"
+    usage-level: "&4Usage: &f/level [<level>] [<player>]"
     no-permission: "&4Dir fehlt das Recht &f%perm%&4!"
     player-not-found: "&4Kein Spieler mit dem Namen &f%name%&4 online!"
-    foodlevel-above-max: "&f%input% &4ist höher als das maximale Foodlevel!"
-    saturation-above-max: "&f%input% &4ist höher als das maximale Sättigungslevel!"
-    health-above-max: "&f%input% &4ist höher als dein maximales Leben!"
-    xp-above-max: "&f%input% &4ist höher als die maximale Erfahrung!"
-    level-above-max: "&f%input% &4ist höher als die maximale Erfahrung!"
-    wrong-foodlevel: "&f%input% &4ist keine ganze Zahl!"
+    hunger-range: "&f%input% &4ist kleiner oder höher als das mögliche Hungerlevel (0 bis 20)!"
+    saturation-range: "&f%input% &4ist kleiner oder höher als das mögliche Sättigungslevel (0 bis 20)!"
+    health-range: "&f%input% &4ist kleiner oder höher als die möglichen Leben (0 bis 20)!"
+    xp-range: "&f%input% &4ist kleiner oder höher als die mögliche Erfahrung (0 bis 2147483647)!"
+    level-range: "&f%input% &4ist kleiner oder höher als die mögliche Erfahrung (0 bis 2147483647)!"
+    wrong-hunger: "&f%input% &4ist keine ganze Zahl!"
     wrong-saturation: "&f%input% &4ist keine Zahl!"
     wrong-health: "&f%input% &4ist keine Zahl!"
     wrong-xp: "&f%input% &4ist keine Zahl!"
-  success-foodlevel:
+    wrong-level: "&f%input% &4ist keine Zahl!"
+  success-hunger:
     own: "&7Hunger auf %value% gesetzt!"
     other: "&f%name%&7's Hunger auf %value% gesetzt!"
   success-saturation:
@@ -31,13 +33,13 @@ lang:
     own: "&7Level auf %value% gesetzt!"
     other: "&f%name%&7's Level auf %value% gesetzt!"
   current-level:
-    foodlevel: "&7Du hast momentan &f%value%&7 Hunger!"
+    hunger: "&7Du hast momentan &f%value%&7 Hunger!"
     saturation: "&7Du hast momentan &f%value%&7 Sättigung!"
     health: "&7Du hast momentan &f%value%&7 Leben!"
     xp: "&7Du hast momentan &f%value%&7 Erfahrung!"
     level: "&7Du hast momentan &f%value%&7 Level!"
   current-level-other:
-    foodlevel: "&f%player%&7 hat momentan &f%value%&7 Hunger!"
+    hunger: "&f%player%&7 hat momentan &f%value%&7 Hunger!"
     saturation: "&f%player%&7 hat momentan &f%value%&7 Sättigung!"
     health: "&f%player%&7 hat momentan &f%value%&7 Leben!"
     xp: "&f%player%&7 hat momentan &f%value%&7 Erfahrung!"


### PR DESCRIPTION
For example, if you enter the command `/health -1` (or `/exp -1` or `/level -1` ...), an internal server error occurs.
The reason for this is, that no minimum values have been set for the commands, but the system cannot process this information.


For this reason, the minimum values have been added in this pull request and further changes have been made to messages.

During this bugfix work, two other errors occurred:
1. The hunger command is labeled as `foodlevel` in the code, but declared as `hunger` command. The corresponding message placeholders have therefore been adjusted.
2. Some placeholders were missing for the `level` command.

![image](https://github.com/RedstoneWorld/RedPlayerUtils/assets/93550632/86e8c694-de63-4ec0-a654-c600f62148ab)


The following changes will be implemented:
- Minimum values for commands added.
- Queries extended.
- Messages for all commands changed to "lower or higher" (range) values.
- Messages for the Hunger command corrected.
- Missing messages for the level command added.